### PR TITLE
Add seeded random-string hidden/optional data point

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -38,3 +38,10 @@ class KubeDNSProvider(RelationBase):
                        'sdn-ip': sdn_ip}
         conv = self.conversation()
         conv.set_remote(data=credentials)
+
+    def set_seed(self, seed):
+        ''' Use this method to invoke a relationship-changed hook on the
+        remote unit during times of remote negotiation for cluster-hosted
+        dns '''
+        conv = self.conversation()
+        conv.set_remote(data={'random-seed': seed})

--- a/requires.py
+++ b/requires.py
@@ -42,7 +42,12 @@ class KubeDNSRequireer(RelationBase):
                 return False
         return True
 
+    def current_seed(self):
+        ''' Return the random seed sent on the wire during worker
+        remote interrogation. Use this value to determine render
+        and recycle states '''
+        return self._get_value('random-seed')
+
     def _get_value(self, key):
         conv = self.conversation()
         return conv.get_remote(key)
-


### PR DESCRIPTION
This adds a set_seed and get_seed method on the kube-dns relationship
communication protocol. This seed can be used to control expiring cache,
or breaking the deadlock of kube-worker turnup, by invoking a
relation-cahnged event on the requiring units.
